### PR TITLE
[#130188061] Add ability to disallow pull requests from forks

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ concourse version 1.2.x and higher and the [`version: every`](http://concourse.c
   See the [`git-config(1)` manual page](https://www.kernel.org/pub/software/scm/git/docs/git-config.html)
   for more information and documentation of existing git options.
 
+* `disallow_forks`: *Optional*. If set to `true` it will only detect pull requests raised from within the same repository. Pull requests from forks will not generate new versions of the resource within Concourse. The default value is `false`.
+
 ## Behavior
 
 ### `check`: Check for new pull requests

--- a/assets/check
+++ b/assets/check
@@ -5,6 +5,8 @@ set -e
 exec 3>&1 # make stdout available as fd 3 for the result
 exec 1>&2 # redirect all output to stderr for logging
 
+. $(dirname $0)/common.sh
+
 payload=$(mktemp $TMPDIR/pullrequest-resource.XXXXXX)
 cat > $payload <&0
 

--- a/assets/lib/commands/check.rb
+++ b/assets/lib/commands/check.rb
@@ -10,7 +10,7 @@ module Commands
 
     def output
       if return_all_versions?
-        repo.pull_requests
+        all_pull_requests
       else
         next_pull_request
       end
@@ -22,11 +22,20 @@ module Commands
       input['source']['every'] == true
     end
 
+    def disallow_forks?
+      input['source']['disallow_forks'] == true
+    end
+
+    def all_pull_requests
+      repo.pull_requests(disallow_forks: disallow_forks?)
+    end
+
     def next_pull_request
       pull_request = repo.next_pull_request(
         id: input['version']['pr'],
         sha: input['version']['ref'],
-        base: input['source']['base']
+        base: input['source']['base'],
+        disallow_forks: disallow_forks?,
       )
 
       if pull_request

--- a/assets/lib/pull_request.rb
+++ b/assets/lib/pull_request.rb
@@ -10,6 +10,10 @@ class PullRequest
     statuses.empty?
   end
 
+  def from_fork?
+    base_repo != head_repo
+  end
+
   def equals?(id:, sha:)
     [self.sha, self.id.to_s] == [sha, id.to_s]
   end
@@ -35,6 +39,14 @@ class PullRequest
   end
 
   private
+
+  def base_repo
+    @pr['base']['repo']['full_name']
+  end
+
+  def head_repo
+    @pr['head']['repo']['full_name']
+  end
 
   def statuses
     @statuses ||= Octokit.statuses(@repo.name, sha).select do |status|

--- a/assets/lib/repository.rb
+++ b/assets/lib/repository.rb
@@ -8,8 +8,8 @@ class Repository
     @name = name
   end
 
-  def pull_requests(args = {})
-    @pull_requests ||= Octokit.pulls(name, pulls_options(args)).map do |pr|
+  def pull_requests(base: nil)
+    @pull_requests ||= Octokit.pulls(name, pulls_options(base: base)).map do |pr|
       PullRequest.new(repo: self, pr: pr)
     end
   end


### PR DESCRIPTION
## What

[#130188061 - Migrate existing AWS-RDS bosh release builds to use pullrequest-resource based builds](https://www.pivotaltracker.com/story/show/130188061)

In some cases you may want to only allow pull requests from within your own team. This is useful in scenarios where you cannot have untrusted code being pulled into your Concourse pipeline.

This commit adds the ability to optionally set a `disallow_forks` configuration, which if set to true will only consider pull requests valid if they are raised from within the same repository. The value of this configuration is false by default and does not interfere with the normal behaviour of the resource.

## How to review

Review as part of https://github.com/alphagov/paas-release-ci/pull/1

Also: 

* Run the rspec tests: `bundle install && bundle exec rspec`
* Code review

## Who 

Anyone but me or @alext 